### PR TITLE
add correct home link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ About pyautogen-feedstock
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/pyautogen-feedstock/blob/main/LICENSE.txt)
 
-Home: https://github.com/microsoft/autogen
+Home: https://github.com/ag2ai/ag2
 
-Package license: MIT
+Package license: Apache-2.0
 
-Summary: Enabling Next-Gen LLM Applications via Multi-Agent Conversation Framework
+Summary: A programming framework for agentic AI
 
 Current build status
 ====================

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -45,10 +45,12 @@ test:
     - python {{ python_min }}
 
 about:
-  home: https://github.com/microsoft/autogen
-  summary: Enabling Next-Gen LLM Applications via Multi-Agent Conversation Framework
-  license: MIT
-  license_file: LICENSE
+  home: https://github.com/ag2ai/ag2
+  summary: A programming framework for agentic AI
+  license: Apache-2.0
+  license_file:
+    - NOTICE.md
+    - LICENSE
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Fiendly ping @jan-janssen. As I mentioned in https://github.com/conda-forge/pyautogen-feedstock/pull/16#issue-2761796322:
 - The link for pyautogen is now https://github.com/ag2ai/ag2 (you can check the links on that left side of the screen at https://pypi.org/project/pyautogen/).
 - I ran the recipe through greyskull and got updates licenses. The license is now APACHE not MIT (https://github.com/ag2ai/ag2/blob/main/LICENSE)
 - For the original microsoft autogen, i'm working on that here: https://github.com/conda-forge/staged-recipes/pull/28696

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
