### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-About pyautogen-feedstock
+About ag2-feedstock
 =========================
 
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/pyautogen-feedstock/blob/main/LICENSE.txt)
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/ag2-feedstock/blob/main/LICENSE.txt)
 
 Home: https://github.com/ag2ai/ag2
 
@@ -16,7 +16,7 @@ Current build status
 <table><tr><td>All platforms:</td>
     <td>
       <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=22976&branchName=main">
-        <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyautogen-feedstock?branchName=main">
+        <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ag2-feedstock?branchName=main">
       </a>
     </td>
   </tr>
@@ -27,53 +27,53 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-pyautogen-green.svg)](https://anaconda.org/conda-forge/pyautogen) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pyautogen.svg)](https://anaconda.org/conda-forge/pyautogen) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pyautogen.svg)](https://anaconda.org/conda-forge/pyautogen) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pyautogen.svg)](https://anaconda.org/conda-forge/pyautogen) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-ag2-green.svg)](https://anaconda.org/conda-forge/ag2) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/ag2.svg)](https://anaconda.org/conda-forge/ag2) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ag2.svg)](https://anaconda.org/conda-forge/ag2) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/ag2.svg)](https://anaconda.org/conda-forge/ag2) |
 
-Installing pyautogen
+Installing ag2
 ====================
 
-Installing `pyautogen` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `ag2` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `pyautogen` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `ag2` can be installed with `conda`:
 
 ```
-conda install pyautogen
-```
-
-or with `mamba`:
-
-```
-mamba install pyautogen
-```
-
-It is possible to list all of the versions of `pyautogen` available on your platform with `conda`:
-
-```
-conda search pyautogen --channel conda-forge
+conda install ag2
 ```
 
 or with `mamba`:
 
 ```
-mamba search pyautogen --channel conda-forge
+mamba install ag2
+```
+
+It is possible to list all of the versions of `ag2` available on your platform with `conda`:
+
+```
+conda search ag2 --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search ag2 --channel conda-forge
 ```
 
 Alternatively, `mamba repoquery` may provide more information:
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search pyautogen --channel conda-forge
+mamba repoquery search ag2 --channel conda-forge
 
-# List packages depending on `pyautogen`:
-mamba repoquery whoneeds pyautogen --channel conda-forge
+# List packages depending on `ag2`:
+mamba repoquery whoneeds ag2 --channel conda-forge
 
-# List dependencies of `pyautogen`:
-mamba repoquery depends pyautogen --channel conda-forge
+# List dependencies of `ag2`:
+mamba repoquery depends ag2 --channel conda-forge
 ```
 
 
@@ -118,17 +118,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating pyautogen-feedstock
+Updating ag2-feedstock
 ============================
 
-If you would like to improve the pyautogen recipe or build a new
+If you would like to improve the ag2 recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/pyautogen-feedstock are
+Note that all branches in the conda-forge/ag2-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set name = "pyautogen" %}
+{% set name = "ag2" %}
 {% set version = "0.9" %}
 
 package:
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/pyautogen-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/ag2-{{ version }}.tar.gz
   sha256: 58763009b6f6f988cdf9bb908c56a61a60c16e772096ab621edf06748fa58e50
 
 build:


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using AG2! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
